### PR TITLE
[FEAT] Product별 Protocol interface 추가

### DIFF
--- a/CRA_SSDProject.sln
+++ b/CRA_SSDProject.sln
@@ -1,0 +1,47 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.10.34928.147
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "CRA_SSDProject", "CRA_SSDProject\CRA_SSDProject.vcxproj", "{D5E638E6-00B1-4B3F-87AB-608276222B74}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Sample-Test1", "Sample-Test1\Sample-Test1.vcxproj", "{E1DB8E2D-F3FC-4826-9FD1-320D31CE01BC}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "솔루션 항목", "솔루션 항목", "{BD500F09-21D7-42B4-83D5-96C23232FBC4}"
+	ProjectSection(SolutionItems) = preProject
+		.gitignore = .gitignore
+		README.md = README.md
+	EndProjectSection
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{D5E638E6-00B1-4B3F-87AB-608276222B74}.Debug|x64.ActiveCfg = Debug|x64
+		{D5E638E6-00B1-4B3F-87AB-608276222B74}.Debug|x64.Build.0 = Debug|x64
+		{D5E638E6-00B1-4B3F-87AB-608276222B74}.Debug|x86.ActiveCfg = Debug|Win32
+		{D5E638E6-00B1-4B3F-87AB-608276222B74}.Debug|x86.Build.0 = Debug|Win32
+		{D5E638E6-00B1-4B3F-87AB-608276222B74}.Release|x64.ActiveCfg = Release|x64
+		{D5E638E6-00B1-4B3F-87AB-608276222B74}.Release|x64.Build.0 = Release|x64
+		{D5E638E6-00B1-4B3F-87AB-608276222B74}.Release|x86.ActiveCfg = Release|Win32
+		{D5E638E6-00B1-4B3F-87AB-608276222B74}.Release|x86.Build.0 = Release|Win32
+		{E1DB8E2D-F3FC-4826-9FD1-320D31CE01BC}.Debug|x64.ActiveCfg = Debug|x64
+		{E1DB8E2D-F3FC-4826-9FD1-320D31CE01BC}.Debug|x64.Build.0 = Debug|x64
+		{E1DB8E2D-F3FC-4826-9FD1-320D31CE01BC}.Debug|x86.ActiveCfg = Debug|Win32
+		{E1DB8E2D-F3FC-4826-9FD1-320D31CE01BC}.Debug|x86.Build.0 = Debug|Win32
+		{E1DB8E2D-F3FC-4826-9FD1-320D31CE01BC}.Release|x64.ActiveCfg = Release|x64
+		{E1DB8E2D-F3FC-4826-9FD1-320D31CE01BC}.Release|x64.Build.0 = Release|x64
+		{E1DB8E2D-F3FC-4826-9FD1-320D31CE01BC}.Release|x86.ActiveCfg = Release|Win32
+		{E1DB8E2D-F3FC-4826-9FD1-320D31CE01BC}.Release|x86.Build.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {1381DA08-89D9-4AF3-AD7C-4B1A2BDF4F64}
+	EndGlobalSection
+EndGlobal

--- a/TestShell/Sample-Test1/test.cpp
+++ b/TestShell/Sample-Test1/test.cpp
@@ -7,15 +7,7 @@
 using namespace testing;
 using namespace std;
 
-class IProduct
-{
-public:
-	virtual void Write(int addr, string value) {
-	}
-	virtual string Read(int addr) { return ""; }
-};
-
-class ProductMock : public IProduct {
+class ProductMock : public IProtocol {
 public:
 	MOCK_METHOD(void, Write, (int addr, string value), (override));
 	MOCK_METHOD(string, Read, (int addr), (override));

--- a/TestShell/Sample-Test1/test.cpp
+++ b/TestShell/Sample-Test1/test.cpp
@@ -11,8 +11,6 @@ class ProductMock : public IProtocol {
 public:
 	MOCK_METHOD(void, Write, (int addr, string value), (override));
 	MOCK_METHOD(string, Read, (int addr), (override));
-	MOCK_METHOD(void, FullWrite, (string value), ());
-	MOCK_METHOD(string, FullRead, (), ());
 };
 
 class TestShellFixture : public Test {
@@ -23,10 +21,7 @@ public:
 
 
 TEST_F(TestShellFixture, ReadFailTest) {
-	ProductMock mock;
-
-	EXPECT_THROW(mock.Read(110), exception);
-
+	EXPECT_THROW(pMock.Read(110), exception);
 }
 
 TEST_F(TestShellFixture, writeWrongAddrWrite) {	

--- a/TestShell/Sample-Test1/test.cpp
+++ b/TestShell/Sample-Test1/test.cpp
@@ -5,17 +5,41 @@
 #include "gmock/gmock.h"
 
 using namespace testing;
+using namespace std;
 
 
-class Mock : public TestShell {
+class MockTestShell : public TestShell {
 public:
-	MOCK_METHOD(void, Write, (int addr, string value), (override));
-	MOCK_METHOD(string, Read, (int addr), (override));
-	MOCK_METHOD(void, FullWrite, (string value), (override));
-	MOCK_METHOD(string, FullRead, , (override));
+	MOCK_METHOD(void, Write, (int addr, string value), ());
+	MOCK_METHOD(string, Read, (int addr), ());
+	MOCK_METHOD(void, FullWrite, (string value), ());
+	MOCK_METHOD(string, FullRead, (), ());
 };
-
 
 TEST(TestCaseName, TestName) {
 	EXPECT_THAT(1, Eq(1));
+}
+
+TEST(ShellReadTest, ReadTest) {
+	MockTestShell mock;
+
+	EXPECT_CALL(mock, Read(0)).WillOnce(Return("Ox00000000"));
+
+	cout << mock.Read(0) << "\n";
+}
+
+TEST(ShellReadTest, ReadFailTest) {
+	MockTestShell mock;
+
+	EXPECT_THROW(mock.Read(110), exception);
+
+}
+
+TEST(ShellReadTest, FullReadTest) {
+	MockTestShell mock;
+
+	EXPECT_CALL(mock, FullRead()).Times(1);
+	EXPECT_CALL(mock, Read(_)).Times(100);
+
+	cout << mock.FullRead() << "\n";
 }

--- a/TestShell/TestShell/TestShell.cpp
+++ b/TestShell/TestShell/TestShell.cpp
@@ -3,6 +3,23 @@
 
 using namespace std;
 
+__interface IProtocol
+{
+	virtual void Write(int addr, string value) = 0;
+	virtual string Read(int addr) = 0;
+};
+
+class SSDProtocol : public IProtocol
+{
+public:
+	virtual void Write(int addr, string value) override {
+
+	}
+
+	virtual string Read(int addr) override {
+		return "";
+	}
+};
 
 class TestShell {
 public:


### PR DESCRIPTION
1. 해당 interface 객체를통해 SSD나 추후 product 테스트용에 따른 read, write 방식 변경 가능하도록
2. 구글 test에서는 해당 interface의 mock을 생성하여 test 처리