### PR TITLE
add global teardown in Unitest

### DIFF
--- a/SSD/Sample-Test1/test.cpp
+++ b/SSD/Sample-Test1/test.cpp
@@ -17,8 +17,7 @@ public:
 
     SSD ssd;
     CommandInvoker invoker{ &ssd };
-    void SetUp()
-    {
+    void SetUp() override {
         invoker.addCommand(std::move(std::make_unique<WriteCommand>()));
         invoker.addCommand(std::move(std::make_unique<ReadCommand>()));
     }

--- a/SSD/Sample-Test1/test.cpp
+++ b/SSD/Sample-Test1/test.cpp
@@ -22,6 +22,13 @@ public:
         invoker.addCommand(std::move(std::make_unique<WriteCommand>()));
         invoker.addCommand(std::move(std::make_unique<ReadCommand>()));
     }
+
+    void TearDown() override {
+        LPCWSTR nandPath = L"nand.txt";
+        LPCWSTR outputPath = L"result.txt";
+        DeleteFile(nandPath);
+        DeleteFile(outputPath);
+    };
 };
 
 TEST_F(SSDFIxture, SsdWrite0) {
@@ -76,9 +83,6 @@ TEST_F(SSDFIxture, SsdBrokenFile) {
     EXPECT_THROW({
          ssd.read(0);
         }, ssd_exception);
-
-    LPCWSTR path = L"nand.txt";
-    DeleteFile(path);
 }
 
 TEST_F(SSDFIxture, CommandInvokerWrite0) {


### PR DESCRIPTION
Add global teardown to remove dependency between test.