### PR TITLE
Dev/ssd 3rd hotfix

### DIFF
--- a/SSD/SSD/Invoker.cpp
+++ b/SSD/SSD/Invoker.cpp
@@ -17,11 +17,9 @@ public:
             if (argv[1] == command->getCommandCode())
             {
                 int ret = command->execute(argc, argv, ssd);
-                commands.clear();
                 return ret;
             }
         }
-        commands.clear();
         return 0;
     }
 private:

--- a/SSD/SSD/Invoker.cpp
+++ b/SSD/SSD/Invoker.cpp
@@ -5,6 +5,7 @@
 class CommandInvoker {
 private:
     std::vector<std::unique_ptr<ICommand>> commands;
+    SSD* ssd = nullptr;
 
 public:
     CommandInvoker(SSD* ssd) : ssd(ssd) {}
@@ -13,15 +14,24 @@ public:
     }
 
     int executeCommands(int argc, char* argv[]) {
+        int ret = commandValidation(argc, argv);
+        if (ret == ICommand::COMMAND_VALIDATION_FAIL)
+            return ret;
+
         for (const auto& command : commands) {
             if (argv[1] == command->getCommandCode())
             {
-                int ret = command->execute(argc, argv, ssd);
+                ret = command->execute(argc, argv, ssd);
                 return ret;
             }
         }
         return 0;
     }
 private:
-    SSD* ssd = nullptr;
+    int commandValidation(int argc, char* argv[])
+    {
+        if (argc < 3 || argc > 5)
+            return ICommand::COMMAND_VALIDATION_FAIL;
+        return ICommand::COMMAND_VALIDATION_SUCCESS;
+    }
 };

--- a/SSD/SSD/main.cpp
+++ b/SSD/SSD/main.cpp
@@ -2,7 +2,7 @@
 #include <memory>
 #include "Invoker.cpp"
 #include "Write.cpp"
-#include "Read.cpp""
+#include "Read.cpp"
 
 int main(int argc, char* argv[])
 {

--- a/SSD/Sample-Test1/test.cpp
+++ b/SSD/Sample-Test1/test.cpp
@@ -97,7 +97,7 @@ TEST_F(SSDFIxture, CommandInvokerRead0) {
     char* argv[] = { "ssd.exe", "R", "0"};
     int ret = invoker.executeCommands(argc, argv);
    
-    int expectedData = 0xdeadbeef;
+    int expectedData = 0;
     EXPECT_THAT(ret, testing::Eq(expectedData));
 }
 

--- a/SSD/Sample-Test1/test.cpp
+++ b/SSD/Sample-Test1/test.cpp
@@ -118,3 +118,29 @@ TEST_F(SSDFIxture, CommandInvokerRead100) {
          invoker.executeCommands(argc, argv);
         }, ssd_exception);
 }
+
+TEST_F(SSDFIxture, CommandInvokerWriteRead0Verify) {
+    int argc = 4;
+    char* argv[] = { "ssd.exe", "W", "0", "0xdeadbeef" };
+    invoker.executeCommands(4, argv);
+    argc = 3;
+    argv[1] = "R";
+    argv[3] = "";
+    int ret = invoker.executeCommands(argc, argv);
+
+    int expectedData = 0xdeadbeef;
+    EXPECT_THAT(ret, testing::Eq(expectedData));
+}
+
+TEST_F(SSDFIxture, CommandInvokerWriteRead50Verify) {
+    int argc = 4;
+    char* argv[] = { "ssd.exe", "W", "50", "0xdeadbeef" };
+    invoker.executeCommands(4, argv);
+    argc = 3;
+    argv[1] = "R";
+    argv[3] = "";
+    int ret = invoker.executeCommands(argc, argv);
+
+    int expectedData = 0xdeadbeef;
+    EXPECT_THAT(ret, testing::Eq(expectedData));
+}


### PR DESCRIPTION
잘못된 expected data 수정
잘못된 쌍따옴표 제거
데이터 정합성 검사하는 test추가
파라미터 없이 실행될 때 exception 발생하는 부분 개선
