### PR TITLE
[FEAT] system cmd 처리부 수정 및 Debug 관련 실행 path 수정

### DIFF
--- a/TestShell/TestShell/ProductInterface.h
+++ b/TestShell/TestShell/ProductInterface.h
@@ -23,16 +23,18 @@ public:
 	virtual void Write(int addr, string value) override {		
 		string cmd = curPath;
 		cmd.append(mExecuteName + " W " + std::to_string(addr) + " " + value);
-		if (system(cmd.c_str()) != 0)
-			cout << "실행파일을 실행하지 못했습니다." << endl;
+		int res = system(cmd.c_str());
+		if (res != 0)
+			cout << "실행파일을 실행하지 못했습니다. : " << res << " - " << cmd << endl;
 		
 	}
 
 	virtual string Read(int addr) override {
 		string cmd = curPath;
 		cmd.append(mExecuteName + " R " + std::to_string(addr));
-		if (system(cmd.c_str()) != 0)
-			cout << "실행파일을 실행하지 못했습니다." << endl;
+		int res = system(cmd.c_str());
+		if (res != 0)
+			cout << "실행파일을 실행하지 못했습니다. : "<< res << " - " << cmd << endl;
 
 		ifstream readFile;
 		string result;
@@ -45,7 +47,7 @@ public:
 		}
 		else
 		{
-			cout << "결과 파일을 읽지 못했습니다." << endl;
+			cout << "결과 파일을 읽지 못했습니다. : " << cmd << endl;
 		}
 		readFile.close();
 		return result;
@@ -54,14 +56,15 @@ public:
 	virtual void Erase(int addr, int size) override {
 		string cmd = curPath;
 		cmd.append(mExecuteName + " E " + std::to_string(addr) + " " + std::to_string(size));
-		if (system(cmd.c_str()) != 0)
-			cout << "실행파일을 실행하지 못했습니다." << endl;
+		int res = system(cmd.c_str());
+		if (res != 0)
+			cout << "실행파일을 실행하지 못했습니다. : " << res << " - " << cmd << endl;
 	}
 private:
 	char curPath[256];
 
 	string mReadFileName = "result.txt";
-	string mExecuteName = "\\..\\..\\SSD\\x64\\Debug\\ssd.exe";
+	string mExecuteName = "\\ssd.exe";
 };
 
 class createProductFactory {

--- a/TestShell/TestShell/TestShell.vcxproj.user
+++ b/TestShell/TestShell/TestShell.vcxproj.user
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LocalDebuggerWorkingDirectory>$(SolutionDir)$(Platform)\$(Configuration)\</LocalDebuggerWorkingDirectory>
+    <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
1. systme cmd 결과 값 및 실패시 cmd 정보 출력 되도록 변경
2. window cmd 창에서 실행시 folder path 처리를 위해 무조건 testshell.exe 파일 위치에서 실행 되도록 변경 -> debug 테스트시 실행 위치 설정을 빌드 파일이 생성되는 곳으로 처리하여 개발 간에도 불편하지 않게 변경