### PR TITLE
[FEAT] SSD 프로젝트 빌드 시 SSD.exe 파일 copy

### DIFF
--- a/SSD/SSD/SSD.vcxproj
+++ b/SSD/SSD/SSD.vcxproj
@@ -113,6 +113,9 @@
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
+    <PostBuildEvent>
+      <Command>copy "$(SolutionDir)$(Platform)\$(Configuration)\$(TargetFileName)" "$(SolutionDir)..\TestShell\x64\Debug";</Command>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>


### PR DESCRIPTION
1. 빌드 후 이벤트로 testshell로 copy하도록 프로젝트 설정.