### PR TITLE
remove inline variable

### DIFF
--- a/SSD/Sample-Test1/test.cpp
+++ b/SSD/Sample-Test1/test.cpp
@@ -31,12 +31,9 @@ public:
     }
 
     void TearDown() override {
-        LPCWSTR nandPath = L"nand.txt";
-        LPCWSTR outputPath = L"result.txt";
-        LPCWSTR cmdlistPath = L"cmdlist.txt";
-        DeleteFile(nandPath);
-        DeleteFile(outputPath);
-        DeleteFile(cmdlistPath);
+        DeleteFile(wstring(NAND.begin(), NAND.end()).c_str());
+        DeleteFile(wstring(OUTPUT.begin(), OUTPUT.end()).c_str());
+        DeleteFile(wstring(CMDFILE.begin(), CMDFILE.end()).c_str());
     };
 
     int readResult()


### PR DESCRIPTION
We don't need LPCWSTR variable.