### PR TITLE
Fixed bug on scanPreviousWriteMergeSameRangeWriteErase

### DIFF
--- a/SSD/SSD/storage.cpp
+++ b/SSD/SSD/storage.cpp
@@ -362,7 +362,8 @@ private:
 		{
 			if (cmdUnder->cmdOpcode == COMMAND_WRITE)
 			{
-				isMerged = mergePreviousWriteIfSameRange(beginAddress, cmdUnder, endAddress, commands);
+				if (mergePreviousWriteIfSameRange(beginAddress, cmdUnder, endAddress, commands))
+					isMerged = true;
 			}
 
 			if (cmdUnder == commands.begin())


### PR DESCRIPTION
2 중 for loop의 iterator로 사용되는 vector iterator가 잘못 관리되어 invalid access 발생하는 문제였습니다. 
Refactoring 중 잘못 수정된 부분이 있어서 발생했습니다.
TDD의 필요성을 다시 한번 느꼈네요
(fast write부분이라 TDD가 부족한 점이 있었습니다.)